### PR TITLE
Move is_activated check to the authorization server logic.

### DIFF
--- a/api/v1/authentications.py
+++ b/api/v1/authentications.py
@@ -1,11 +1,8 @@
 import requests
 
 from django.conf import settings
-from django.contrib.auth import authenticate
-from django.utils import timezone
 
 from oauth2_provider.models import Application
-from rest_framework.exceptions import AuthenticationFailed
 
 
 class OAuthHandler:
@@ -38,24 +35,11 @@ class UserAuthentication:
     Returns OAuth token.
     """
 
-    def update_last_login(self, user):
-        user.last_login = timezone.now()
-        user.save()
-
     def authenticate(self, **kwargs):
         """
-        First party app authenticates user then requests token from
-        authorization server.
+        First party app requests token from authorization server.
         """
         email = kwargs.get('email')
         password = kwargs.get('password')
-        user = authenticate(email=email, password=password)
-        if not user:
-            raise AuthenticationFailed(detail='Invalid email.')
-        elif not user.is_activated:
-            raise AuthenticationFailed(detail='Unactivated account.')
-
         token = OAuthHandler().request_token(email, password)
-        if token.get('access_token'):
-            self.update_last_login(user)
         return token

--- a/toolbox_generics/urls.py
+++ b/toolbox_generics/urls.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.urls import include
 from django.urls import path
 
-from oauth2_provider.views import TokenView
+from .views import TokenView
 
 
 urlpatterns = [

--- a/toolbox_generics/views.py
+++ b/toolbox_generics/views.py
@@ -1,0 +1,33 @@
+import json
+
+from django.contrib.auth import authenticate
+from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.decorators.debug import sensitive_post_parameters
+
+from oauth2_provider.views import TokenView as BaseTokenView
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class TokenView(BaseTokenView):
+    """
+    Inherits oauth package TokenView. Performs additional check on user's
+    `is_activated` field.
+    """
+
+    def update_last_login(self, user):
+        user.last_login = timezone.now()
+        user.save()
+
+    @method_decorator(sensitive_post_parameters("password"))
+    def post(self, request, *args, **kwargs):
+        data = json.loads(request.body.decode('utf-8'))
+        email = data.get('username')
+        password = data.get('password')
+        user = authenticate(email=email, password=password)
+        if not user:
+            raise AuthenticationFailed(detail='Invalid email.')
+        elif not user.is_activated:
+            raise AuthenticationFailed(detail='Unactivated account.')
+        self.update_last_login(user)
+        return super().post(request, *args, *kwargs)


### PR DESCRIPTION
The authorization flow felt weird since the first party app itself does a user authentication while sharing the same database as the authorization server. This PR resolves that issue and moves is_activated check inside a TokenView inheritance class. First party app no longer identifies the user but simply passes user credentials onto the token endpoint.